### PR TITLE
Added X-Content-Type-Options (nosniff) security feature

### DIFF
--- a/controller.php
+++ b/controller.php
@@ -97,7 +97,7 @@ class Controller extends Package
             $server->addMiddleware($this->app->make(AccessControlAllowOriginPolicyMiddleware::class, ['config' => $accessControlAllowOrigin]));
         }
 
-        $nosniff = $config->get('security.x_content_type_options_nosniff', false);
+        $nosniff = $config->get('security.x_content_type_options', false);
         if ($nosniff) {
             $server->addMiddleware($this->app->make(ContentTypeOptionsMiddleware::class, ['config' => $nosniff]));
         }

--- a/controller.php
+++ b/controller.php
@@ -5,6 +5,7 @@ namespace Concrete\Package\MdSecurityHeaderExtended;
 use Concrete\Core\Http\ServerInterface;
 use Concrete\Core\Package\Package;
 use Macareux\SecurityHeaderExtended\Http\Middleware\AccessControlAllowOriginPolicyMiddleware;
+use Macareux\SecurityHeaderExtended\Http\Middleware\ContentTypeOptionsMiddleware;
 use Macareux\SecurityHeaderExtended\Http\Middleware\CrossOriginEmbedderPolicyMiddleware;
 use Macareux\SecurityHeaderExtended\Http\Middleware\CrossOriginOpenerPolicyMiddleware;
 use Macareux\SecurityHeaderExtended\Http\Middleware\CrossOriginResourcePolicyMiddleware;
@@ -94,6 +95,11 @@ class Controller extends Package
         $accessControlAllowOrigin = $config->get('security.access_control_allow_origin', false);
         if ($accessControlAllowOrigin) {
             $server->addMiddleware($this->app->make(AccessControlAllowOriginPolicyMiddleware::class, ['config' => $accessControlAllowOrigin]));
+        }
+
+        $nosniff = $config->get('security.x_content_type_options_nosniff', false);
+        if ($nosniff) {
+            $server->addMiddleware($this->app->make(ContentTypeOptionsMiddleware::class, ['config' => $nosniff]));
         }
     }
 }

--- a/controllers/single_page/dashboard/system/environment/security_header_extended.php
+++ b/controllers/single_page/dashboard/system/environment/security_header_extended.php
@@ -14,6 +14,7 @@ class SecurityHeaderExtended extends DashboardPageController
         $this->set('coop', $this->getPackageConfig()->get('security.cross_origin_opener_policy'));
         $this->set('coep', $this->getPackageConfig()->get('security.cross_origin_embedder_policy'));
         $this->set('accessControlAllowOrigin', $this->getPackageConfig()->get('security.access_control_allow_origin'));
+        $this->set('nosniff', $this->getPackageConfig()->get('security.x_content_type_options_nosniff'));
     }
 
     protected function getPackageConfig()
@@ -47,13 +48,15 @@ class SecurityHeaderExtended extends DashboardPageController
             if (empty($accessControlAllowOrigin)) {
                 $accessControlAllowOrigin = false;
             }
+            $nosniff = (bool)$this->post('nosniff');
 
             $config = $this->getPackageConfig();
             $config->save('security', [
                 'cross_origin_resource_policy' => $corp,
                 'cross_origin_opener_policy' => $coop,
                 'cross_origin_embedder_policy' => $coep,
-                'access_control_allow_origin' => $accessControlAllowOrigin
+                'access_control_allow_origin' => $accessControlAllowOrigin,
+                'x_content_type_options_nosniff' => $nosniff,
             ]);
 
             $this->flash('success', t('The settings has been successfully updated.'));

--- a/controllers/single_page/dashboard/system/environment/security_header_extended.php
+++ b/controllers/single_page/dashboard/system/environment/security_header_extended.php
@@ -14,7 +14,7 @@ class SecurityHeaderExtended extends DashboardPageController
         $this->set('coop', $this->getPackageConfig()->get('security.cross_origin_opener_policy'));
         $this->set('coep', $this->getPackageConfig()->get('security.cross_origin_embedder_policy'));
         $this->set('accessControlAllowOrigin', $this->getPackageConfig()->get('security.access_control_allow_origin'));
-        $this->set('nosniff', $this->getPackageConfig()->get('security.x_content_type_options_nosniff'));
+        $this->set('nosniff', $this->getPackageConfig()->get('security.x_content_type_options'));
     }
 
     protected function getPackageConfig()
@@ -48,7 +48,10 @@ class SecurityHeaderExtended extends DashboardPageController
             if (empty($accessControlAllowOrigin)) {
                 $accessControlAllowOrigin = false;
             }
-            $nosniff = (bool)$this->post('nosniff');
+            $nosniff = trim($this->post('nosniff'));
+            if (empty($nosniff)) {
+                $nosniff = false;
+            }
 
             $config = $this->getPackageConfig();
             $config->save('security', [
@@ -56,7 +59,7 @@ class SecurityHeaderExtended extends DashboardPageController
                 'cross_origin_opener_policy' => $coop,
                 'cross_origin_embedder_policy' => $coep,
                 'access_control_allow_origin' => $accessControlAllowOrigin,
-                'x_content_type_options_nosniff' => $nosniff,
+                'x_content_type_options' => $nosniff,
             ]);
 
             $this->flash('success', t('The settings has been successfully updated.'));

--- a/single_pages/dashboard/system/environment/security_header_extended.php
+++ b/single_pages/dashboard/system/environment/security_header_extended.php
@@ -27,6 +27,7 @@ $coepOptions = [
     'require-corp' => 'require-corp',
 ];
 $accessControlAllowOrigin = isset($accessControlAllowOrigin) ? $accessControlAllowOrigin : null;
+$nosniff = isset($nosniff) ? $nosniff : false;
 
 $app = Concrete\Core\Support\Facade\Application::getFacadeApplication();
 $site = $app->make('site')->getSite();
@@ -86,6 +87,22 @@ $site = $app->make('site')->getSite();
             <p><?= t('See also:') ?></p>
             <ul>
                 <li><a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin" target="_blank">MDN Web Docs: Access-Control-Allow-Origin</a></li>
+                <li><a href="https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html" target="_blank">OWASP Cheat Sheet Series: HTTP Security Response Headers Cheat Sheet</a></li>
+            </ul>
+        </div>
+    </div>
+
+    <div class="form-group">
+        <?= $form->label('', t('X-Content-Type-Options')) ?>
+        <div class="form-check">
+            <?= $form->checkbox('nosniff', '1', $nosniff) ?>
+            <?= $form->label('nosniff', t('Enable X-Content-Type-Options (nosniff)')) ?>
+        </div>
+        <div class="help-block">
+            <p><?= t('The X-Content-Type-Options response header is used to protect against MIME type confusion attacks by ensuring that browsers do not interpret files as something other than their declared content type.') ?></p>
+            <p><?= t('See also:') ?></p>
+            <ul>
+                <li><a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options" target="_blank">MDN Web Docs: X-Content-Type-Options</a></li>
                 <li><a href="https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html" target="_blank">OWASP Cheat Sheet Series: HTTP Security Response Headers Cheat Sheet</a></li>
             </ul>
         </div>

--- a/single_pages/dashboard/system/environment/security_header_extended.php
+++ b/single_pages/dashboard/system/environment/security_header_extended.php
@@ -95,8 +95,8 @@ $site = $app->make('site')->getSite();
     <div class="form-group">
         <?= $form->label('', t('X-Content-Type-Options')) ?>
         <div class="form-check">
-            <?= $form->checkbox('nosniff', '1', $nosniff) ?>
-            <?= $form->label('nosniff', t('Enable X-Content-Type-Options (nosniff)')) ?>
+            <?= $form->checkbox('nosniff', 'nosniff', $nosniff) ?>
+            <?= $form->label('nosniff', t('Enable X-Content-Type-Options')) ?>
         </div>
         <div class="help-block">
             <p><?= t('The X-Content-Type-Options response header is used to protect against MIME type confusion attacks by ensuring that browsers do not interpret files as something other than their declared content type.') ?></p>

--- a/src/Http/Middleware/ContentTypeOptionsMiddleware.php
+++ b/src/Http/Middleware/ContentTypeOptionsMiddleware.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Macareux\SecurityHeaderExtended\Http\Middleware;
+
+use Concrete\Core\Http\Middleware\DelegateInterface;
+use Concrete\Core\Http\Middleware\MiddlewareInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+class ContentTypeOptionsMiddleware implements MiddlewareInterface
+{
+    private $config;
+
+    public function __construct($config)
+    {
+        $this->config = $config;
+    }
+    /**
+     * Process the request and return a response
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     * @param DelegateInterface $frame
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function process(Request $request, DelegateInterface $frame)
+    {
+        $response = $frame->next($request);
+
+        if ($response->headers->has('X-Content-Type-Options') === false) {
+            if ($this->config === true) {
+                $response->headers->set('X-Content-Type-Options', 'nosniff');
+            }
+        }
+
+        return $response;
+    }
+}

--- a/src/Http/Middleware/ContentTypeOptionsMiddleware.php
+++ b/src/Http/Middleware/ContentTypeOptionsMiddleware.php
@@ -4,14 +4,21 @@ namespace Macareux\SecurityHeaderExtended\Http\Middleware;
 
 use Concrete\Core\Http\Middleware\DelegateInterface;
 use Concrete\Core\Http\Middleware\MiddlewareInterface;
+use Concrete\Core\Utility\Service\Validation\Strings;
 use Symfony\Component\HttpFoundation\Request;
 
 class ContentTypeOptionsMiddleware implements MiddlewareInterface
 {
+    /**
+     * @var Strings
+     */
+    private $stringValidator;
+
     private $config;
 
-    public function __construct($config)
+    public function __construct(Strings $stringValidator, $config)
     {
+        $this->stringValidator = $stringValidator;
         $this->config = $config;
     }
     /**
@@ -25,8 +32,8 @@ class ContentTypeOptionsMiddleware implements MiddlewareInterface
         $response = $frame->next($request);
 
         if ($response->headers->has('X-Content-Type-Options') === false) {
-            if ($this->config === true) {
-                $response->headers->set('X-Content-Type-Options', 'nosniff');
+            if ($this->stringValidator->notempty($this->config)) {
+                $response->headers->set('X-Content-Type-Options', $this->config);
             }
         }
 


### PR DESCRIPTION
A new 'nosniff' option was added to the security headers settings, enabling more configuration options for the X-Content-Type-Options header. This enhances security by preventing MIME type confusion attacks, ensuring that browsers interpret files correctly according to their declared content type.